### PR TITLE
luci-mod-admin-full: allow forced upgrade

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/flashops.htm
@@ -74,6 +74,12 @@
 						<input type="checkbox" name="keep" id="keep" checked="checked" />
 					</div>
 				</div>
+				<div class="cbi-value">
+					<label class="cbi-value-title" for="force"><%:Force upgrade%>:</label>
+					<div class="cbi-value-field">
+						<input type="checkbox" name="force" id="force" />
+					</div>
+				</div>
 				<div class="cbi-value cbi-value-last<% if image_invalid then %> cbi-value-error<% end %>">
 					<label class="cbi-value-title" for="image"><%:Image%>:</label>
 					<div class="cbi-value-field">

--- a/modules/luci-mod-admin-full/luasrc/view/admin_system/upgrade.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_system/upgrade.htm
@@ -51,6 +51,7 @@
 		<input type="hidden" name="token" value="<%=token%>" />
 		<input type="hidden" name="step" value="2" />
 		<input type="hidden" name="keep" value="<%=keep and "1" or ""%>" />
+		<input type="hidden" name="force" value="<%=force and "1" or ""%>" />
 		<input class="cbi-button cbi-button-reset" name="cancel" type="submit" value="<%:Cancel%>" />
 		<input class="cbi-button cbi-button-apply" type="submit" value="<%:Proceed%>" />
 	</form>


### PR DESCRIPTION
Enable checkbox to force flashing even if image header check fails. Unset by default.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>